### PR TITLE
Little update to make it working for ns-3.30.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,34 +3,57 @@ A jamming Wifi Module For NS-3
 
 This is an ns-3 module that can be used to perform simulations of a WiFi network.
 
-[Documentation](/guides/content/editing-an-existing-page) 
 
 ## Getting Started
 ### Prerequisites
 
-You need to install ns-3 and clone this repositorie in src. 
+> system: ubuntu 16.04
 
-``` git clone https://github.com/nsnam/ns-3-dev-git ns-3 ```
+1. install **ns-3.30.1** (Not tested on later versions, but it's certain that it won't work on versions after 3.36)
 
-``` git clone ```
+2. install [ns-3 gym, which suited for ns-3.30.1](https://github.com/tkn-tub/ns3-gym/tree/app)  to use and create Smart Mitigation method and Smart Attack (**cannot be skipped**).
 
-Moroever, to use and create Smart Mitigation method and Smart Attack, we need to install the ["ns-3 gym"](https://apps.nsnam.org/app/ns3-gym/) module
+### install the module
 
-```git clone https://github.com/tkn-tub/ns3-gym.git```
+1. download the module **outside** the ns3 project
+    ```
+    git clone https://github.com/cflycloud/JammingWifiModule.git
+    ```
+
+2. copy the folder "jamming" into the `ns-3/src/`
+
+	```
+	cd JammingWifiModule
+	cp -r jamming /your path to ns-3.30.1/ns-3.30.1/src/
+	```
+
+3. copy the follwing files into ` ns-3/src/wifi/model`
+
+   ```
+   interference-helper.cc
+   interference-helper.h
+   wifi-phy.cc
+   wifi-phy.h
+   wifi-preamble.h
+   ```
 
 ### Compilation 
 
 In the ns-3 folder compile and build the code
 
-``` cd ns-3```
+``` 
+cd ns-3
 
-```./waf configure --enable-tests --enable-examples```
+./waf configure --enable-tests --enable-examples
 
-./waf build```
+./waf build
+```
 
 Finally, make sure tests run smoothly with:
 
-```./test.py -s jamming```
+```
+./test.py -s jamming-components-test
+```
 
 If the script returns that the lorawan test suite passed, you are good to go. Otherwise, if tests fail or crash, consider filing an issue
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ In the ns-3 folder compile and build the code
 ``` 
 cd ns-3
 
-./waf configure --enable-tests --enable-examples
+./waf configure --disable-werror --enable-examples --enable-tests
 
 ./waf build
 ```

--- a/jamming/examples/jamming-mitigation-example.cc
+++ b/jamming/examples/jamming-mitigation-example.cc
@@ -29,9 +29,7 @@
 
 #include "ns3/core-module.h"
 #include "ns3/network-module.h"
-#include "ns3/helper-module.h"
 #include "ns3/mobility-module.h"
-#include "ns3/contrib-module.h"
 #include "ns3/wifi-module.h"
 #include "ns3/internet-module.h"
 #include "ns3/energy-module.h"
@@ -236,9 +234,9 @@ main (int argc, char *argv[])
   /** Wifi PHY **/
   /***************************************************************************/
   NslWifiPhyHelper wifiPhy = NslWifiPhyHelper::Default ();
-  wifiPhy.Set ("NslRxGain", DoubleValue (-10));
-  wifiPhy.Set ("NslTxGain", DoubleValue (offset + Prss));
-  wifiPhy.Set ("NslCcaMode1Threshold", DoubleValue (0.0));
+  wifiPhy.Set ("RxGain", DoubleValue (-10));
+  wifiPhy.Set ("TxGain", DoubleValue (offset + Prss));
+  wifiPhy.Set ("CcaEdThreshold", DoubleValue (0.0));
   /***************************************************************************/
 
   /** wifi channel **/

--- a/jamming/examples/jamming-mitigation-example.cc
+++ b/jamming/examples/jamming-mitigation-example.cc
@@ -249,7 +249,7 @@ main (int argc, char *argv[])
 
   /** MAC layer **/
   // Add a non-QoS upper MAC, and disable rate control
-  NqosWifiMacHelper wifiMac = NqosWifiMacHelper::Default ();
+  WifiMacHelper wifiMac;
   wifi.SetRemoteStationManager ("ns3::ConstantRateWifiManager", "DataMode",
       StringValue (phyMode), "ControlMode", StringValue (phyMode));
   // Set it to ad-hoc mode

--- a/jamming/examples/reactive-jammer-example.cc
+++ b/jamming/examples/reactive-jammer-example.cc
@@ -29,9 +29,7 @@
 
 #include "ns3/core-module.h"
 #include "ns3/network-module.h"
-#include "ns3/helper-module.h"
 #include "ns3/mobility-module.h"
-#include "ns3/contrib-module.h"
 #include "ns3/wifi-module.h"
 #include "ns3/internet-module.h"
 #include "ns3/energy-module.h"
@@ -233,9 +231,9 @@ main (int argc, char *argv[])
   /** Wifi PHY **/
   /***************************************************************************/
   NslWifiPhyHelper wifiPhy = NslWifiPhyHelper::Default ();
-  wifiPhy.Set ("NslRxGain", DoubleValue (-10));
-  wifiPhy.Set ("NslTxGain", DoubleValue (offset + Prss));
-  wifiPhy.Set ("NslCcaMode1Threshold", DoubleValue (0.0));
+  wifiPhy.Set ("RxGain", DoubleValue (-10));
+  wifiPhy.Set ("TxGain", DoubleValue (offset + Prss));
+  wifiPhy.Set ("CcaEdThreshold", DoubleValue (0.0));
   /***************************************************************************/
 
   /** wifi channel **/

--- a/jamming/examples/reactive-jammer-example.cc
+++ b/jamming/examples/reactive-jammer-example.cc
@@ -246,7 +246,7 @@ main (int argc, char *argv[])
 
   /** MAC layer **/
   // Add a non-QoS upper MAC, and disable rate control
-  NqosWifiMacHelper wifiMac = NqosWifiMacHelper::Default ();
+  WifiMacHelper wifiMac;
   wifi.SetRemoteStationManager ("ns3::ConstantRateWifiManager", "DataMode",
       StringValue (phyMode), "ControlMode", StringValue (phyMode));
   // Set it to ad-hoc mode

--- a/jamming/examples/wireless-module-utility-example.cc
+++ b/jamming/examples/wireless-module-utility-example.cc
@@ -241,7 +241,7 @@ main (int argc, char *argv[])
 
   /** MAC layer **/
   // Add a non-QoS upper MAC, and disable rate control
-  NqosWifiMacHelper wifiMac = NqosWifiMacHelper::Default ();
+  WifiMacHelper wifiMac;
   wifi.SetRemoteStationManager ("ns3::ConstantRateWifiManager", "DataMode",
                                 StringValue (phyMode), "ControlMode",
                                 StringValue (phyMode));

--- a/jamming/examples/wireless-module-utility-example.cc
+++ b/jamming/examples/wireless-module-utility-example.cc
@@ -29,9 +29,7 @@
 
 #include "ns3/core-module.h"
 #include "ns3/network-module.h"
-#include "ns3/helper-module.h"
 #include "ns3/mobility-module.h"
-#include "ns3/contrib-module.h"
 #include "ns3/wifi-module.h"
 #include "ns3/internet-module.h"
 #include "ns3/energy-module.h"
@@ -228,9 +226,9 @@ main (int argc, char *argv[])
   /** Wifi PHY **/
   /***************************************************************************/
   NslWifiPhyHelper wifiPhy = NslWifiPhyHelper::Default ();
-  wifiPhy.Set ("NslRxGain", DoubleValue (-10));
-  wifiPhy.Set ("NslTxGain", DoubleValue (offset + Prss));
-  wifiPhy.Set ("NslCcaMode1Threshold", DoubleValue (0.0));
+  wifiPhy.Set ("RxGain", DoubleValue (-10));
+  wifiPhy.Set ("TxGain", DoubleValue (offset + Prss));
+  wifiPhy.Set ("CcaEdThreshold", DoubleValue (0.0));
   /***************************************************************************/
 
   /** wifi channel **/

--- a/jamming/test/jamming-components-test.cc
+++ b/jamming/test/jamming-components-test.cc
@@ -31,7 +31,7 @@
 #include "ns3/address.h"
 // wifi
 #include "ns3/nsl-wifi-helper.h"
-#include "ns3/nqos-wifi-mac-helper.h"
+#include "ns3/wifi-mac-helper.h"
 // mobility
 #include "ns3/mobility-helper.h"
 #include "ns3/constant-position-mobility-model.h"
@@ -179,7 +179,7 @@ JammerTypeTest::InstallJammer (std::string jammerType)
   NslWifiChannelHelper wifiChannel ;
   wifiChannel.SetPropagationDelay ("ns3::ConstantSpeedPropagationDelayModel");
   wifiPhy.SetChannel (wifiChannel.Create ());
-  NqosWifiMacHelper wifiMac = NqosWifiMacHelper::Default ();
+  WifiMacHelper wifiMac = WifiMacHelper::Default ();
   wifi.SetRemoteStationManager ("ns3::ConstantRateWifiManager",
                                 "DataMode", StringValue(phyMode),
                                 "ControlMode", StringValue(phyMode));
@@ -302,7 +302,7 @@ JammingMitigationTypeTest::InstallMitigation (std::string mitigationType)
   NslWifiChannelHelper wifiChannel ;
   wifiChannel.SetPropagationDelay ("ns3::ConstantSpeedPropagationDelayModel");
   wifiPhy.SetChannel (wifiChannel.Create ());
-  NqosWifiMacHelper wifiMac = NqosWifiMacHelper::Default ();
+  WifiMacHelper wifiMac;
   wifi.SetRemoteStationManager ("ns3::ConstantRateWifiManager",
                                 "DataMode", StringValue(phyMode),
                                 "ControlMode", StringValue(phyMode));
@@ -534,19 +534,19 @@ WirelessModuleUtilityTest::SimulateTwoNodes (double distance)
   WifiHelper wifi;
   wifi.SetStandard (WIFI_PHY_STANDARD_80211b);
   NslWifiPhyHelper wifiPhy =  NslWifiPhyHelper::Default ();
-  wifiPhy.Set ("NslRxGain", DoubleValue (m_rxGainDbm));
-  wifiPhy.Set ("NslTxGain", DoubleValue (m_txGainDbm));
-  wifiPhy.Set ("NslTxPowerLevels", UintegerValue (1));
-  wifiPhy.Set ("NslTxPowerEnd", DoubleValue (m_txPowerDbm));
-  wifiPhy.Set ("NslTxPowerStart", DoubleValue (m_txPowerDbm));
-  wifiPhy.Set ("NslCcaMode1Threshold", DoubleValue (0.0));
+  wifiPhy.Set ("RxGain", DoubleValue (m_rxGainDbm));
+  wifiPhy.Set ("TxGain", DoubleValue (m_txGainDbm));
+  wifiPhy.Set ("TxPowerLevels", UintegerValue (1));
+  wifiPhy.Set ("TxPowerEnd", DoubleValue (m_txPowerDbm));
+  wifiPhy.Set ("TxPowerStart", DoubleValue (m_txPowerDbm));
+  wifiPhy.Set ("CcaEdThreshold", DoubleValue (0.0));
   wifiPhy.SetPcapDataLinkType (NslWifiPhyHelper::DLT_IEEE802_11_RADIO);
 
   NslWifiChannelHelper wifiChannel ;
   wifiChannel.SetPropagationDelay ("ns3::ConstantSpeedPropagationDelayModel");
   wifiChannel.AddPropagationLoss ("ns3::FriisPropagationLossModel");
   wifiPhy.SetChannel (wifiChannel.Create ());
-  NqosWifiMacHelper wifiMac = NqosWifiMacHelper::Default ();
+  WifiMacHelper wifiMac;
   wifi.SetRemoteStationManager ("ns3::ConstantRateWifiManager",
                                 "DataMode", StringValue(phyMode),
                                 "ControlMode", StringValue(phyMode));

--- a/jamming/wscript
+++ b/jamming/wscript
@@ -67,5 +67,7 @@ def build(bld):
 
     if (bld.env['ENABLE_EXAMPLES']):
       bld.recurse('examples')
+
+    bld.ns3_python_bindings()
       
     

--- a/jamming/wscript
+++ b/jamming/wscript
@@ -32,7 +32,7 @@ def build(bld):
         
     module_test = bld.create_ns3_module_test_library('jamming')
     module_test.source = [
-        '',
+        '/test/jamming-components-test.cc',
         ]
         
     headers = bld(features='ns3header')
@@ -66,6 +66,6 @@ def build(bld):
         ]
 
     if (bld.env['ENABLE_EXAMPLES']):
-      bld.add_subdirs('examples')
+      bld.recurse('examples')
       
     

--- a/jamming/wscript
+++ b/jamming/wscript
@@ -1,7 +1,7 @@
 ## -*- Mode: python; py-indent-offset: 4; indent-tabs-mode: nil; coding: utf-8; -*-
 
 def build(bld):
-    module = bld.create_ns3_module('jamming', ['wifi', 'network'])
+    module = bld.create_ns3_module('jamming', ['wifi', 'network', 'opengym'])
     module.source = [
         'model/my-gym-env-jammer.cc',
         'model/jammer.cc',


### PR DESCRIPTION
I followed the docker file in https://github.com/JammingWiFiNs3/DockerFileJammerNS, which set to use ns-3.30.1. However, the code in fact include some files that has been removed since ns-3.27 and even earlier, making it cannot work smoothly on the ns-3.30.

This PR fix the bug in the "wscript" and all three examples, which can run successfully on ubuntu 16.04 and ns-3.30.1. But the test is still crashed and I think it's beyond my ability to accomplish this.
